### PR TITLE
Added locale as Language metadata in .po file

### DIFF
--- a/src/poxls/xls_to_po.py
+++ b/src/poxls/xls_to_po.py
@@ -47,6 +47,7 @@ def main(locale, input_file, output_file):
     catalog.metadata['PO-Revision-Date'] = po_timestamp(input_file)
     catalog.metadata['Content-Type'] = 'text/plain; charset=UTF-8'
     catalog.metadata['Content-Transfer-Encoding'] = '8bit'
+    catalog.metadata['Language'] = locale
     catalog.metadata['Generated-By'] = 'xls-to-po 1.0'
 
     for sheet in book.worksheets:


### PR DESCRIPTION
Added locale of file as Language field of metadata/header of .po file so that gulp-angular-gettext has an idea what locale po file is for.

I'm aware that in many cases language and locale are not the same. So this is mostly a starting point for asking what would be a better solution for my problem where gulp-angular-gettext expects to find a Language field in the headers of the po file and this is not supplied by po-xls.

An alternative would be to write my po files first using for example poedit (which adds the Language field) and then merge in the result from po-xls using msgmerge or msgcat.
